### PR TITLE
Add work that will allow us to remove "align"

### DIFF
--- a/ExampleApp/ExampleApp/LayoutViewController.swift
+++ b/ExampleApp/ExampleApp/LayoutViewController.swift
@@ -34,11 +34,11 @@ final class LayoutViewController: BaseViewController {
 
         layout.configure { ctx in
             ctx += button.makeConstraints(
-                .align(.bottom),
+                .bottom(),
                 .alignVerticalEdges()
             )
             ctx += redSquare.makeConstraints(
-                .setRelativeSize(to: greenSquare, multiplier: 0.5)
+                .relativeSize(to: greenSquare, multiplier: 0.5)
             )
 
             ctx.when(.horizontallyRegular, { ctx in
@@ -51,22 +51,22 @@ final class LayoutViewController: BaseViewController {
 
                 ctx.when(.width(is: >=, 1_024), { ctx in
                     ctx += greenSquare.makeConstraints(
-                        .setSize(to: CGSize(width: 400, height: 400))
+                        .size(CGSize(width: 400, height: 400))
                     )
                 }, otherwise: { ctx in
                     ctx += greenSquare.makeConstraints(
-                        .setSize(to: CGSize(width: 150, height: 150))
+                        .size(CGSize(width: 150, height: 150))
                     )
                 })
             }, otherwise: { ctx in
                 ctx += greenSquare.makeConstraints(
-                    .align(.centerX),
-                    .align(.centerY, attribute: .bottom, multiplier: 1 / 3),
-                    .setSize(to: CGSize(width: 100, height: 100))
+                    .centerX(),
+                    .centerY(attribute: .bottom, multiplier: 1 / 3),
+                    .size(CGSize(width: 100, height: 100))
                 )
                 ctx += redSquare.makeConstraints(
-                    .align(.leading, to: greenSquare),
-                    .align(.top, to: greenSquare)
+                    .leading(to: greenSquare),
+                    .top(to: greenSquare)
                 )
             })
         }

--- a/Examples.playground/Contents.swift
+++ b/Examples.playground/Contents.swift
@@ -10,16 +10,6 @@ view.addSubview(container)
 view.addSubview(button)
 view.addSubview(otherButton)
 
-// Aligning
-button.makeConstraints(
-    .align(.leading, .equal, to: button.superview, attribute: .leading, multiplier: 1, constant: 0),
-    .align(.leading, .equal, to: button.superview, attribute: .leading, multiplier: 1),
-    .align(.leading, .equal, to: button.superview, attribute: .leading),
-    .align(.leading, .equal, to: button.superview),
-    .align(.leading, .equal),
-    .align(.leading)
-)
-
 // are all equivalent the following:
 
 NSLayoutConstraint(
@@ -43,8 +33,8 @@ container.makeConstraints(
 
 // Fixed dimensions
 button.makeConstraints(
-    .setFixed(.width, to: 100),
-    .setFixed(.width, .greaterThanOrEqual, to: 100)
+    .fixedWidth(100),
+    .fixedWidth(.greaterThanOrEqual, 100)
 )
 
 // Centering
@@ -55,36 +45,36 @@ button.makeConstraints(
 
 // Relative dimensions
 button.makeConstraints(
-    .setRelative(.height),
-    .setRelative(.height, to: otherButton),
-    .setRelative(.height, to: otherButton, multiplier: 0.5),
-    .setRelative(.height, .lessThanOrEqual, to: otherButton),
-    .setRelative(.height, .equal, to: otherButton, attribute: .width, multiplier: 0.5, constant: 10)
+    .relativeHeight(),
+    .relativeHeight(to: otherButton),
+    .relativeHeight(to: otherButton, multiplier: 0.5),
+    .relativeHeight(.lessThanOrEqual, to: otherButton),
+    .relativeHeight(.equal, to: otherButton, attribute: .width, multiplier: 0.5, constant: 10)
 )
 
 // Setting size
 button.makeConstraints(
-    .setSize(.greaterThanOrEqual, to: CGSize(width: 100, height: 100)),
-    .setSize(to: CGSize(width: 100, height: 100))
+    .size(.greaterThanOrEqual, CGSize(width: 100, height: 100)),
+    .size(CGSize(width: 100, height: 100))
 )
 
 // Matching size
 button.makeConstraints(
-    .setRelativeSize(),
-    .setRelativeSize(to: otherButton),
-    .setRelativeSize(to: otherButton, multiplier: 0.5),
-    .setRelativeSize(.lessThanOrEqual, to: otherButton)
+    .relativeSize(),
+    .relativeSize(to: otherButton),
+    .relativeSize(to: otherButton, multiplier: 0.5),
+    .relativeSize(.lessThanOrEqual, to: otherButton)
 )
 
 // Adding custom debug identifiers
 button.makeConstraints(
-    .align(.leading) <- "yay"
+    .leading() <- "yay"
 )
 
 // Auto debug identifiers
 ConstraintGroup.debugConstraints = true
 let constraints = button.makeConstraints(
-    .align(.leading)
+    .leading()
 )
 
 constraints.first?.identifier
@@ -92,9 +82,9 @@ constraints.first?.identifier
 // Using priority to give a button a nice chunky width, but not go outside the
 // edges of the screen on narrower devices.
 button.makeConstraints(
-    .setFixed(.width, to: 320) ~ .defaultHigh,
-    .align(.leading, .greaterThanOrEqual, to: view.readableContentGuide),
-    .align(.trailing, .lessThanOrEqual, to: view.readableContentGuide)
+    .fixedWidth(320) ~ .defaultHigh,
+    .leading(.greaterThanOrEqual, to: view.readableContentGuide),
+    .trailing(.lessThanOrEqual, to: view.readableContentGuide)
 )
 
 // Easily write extensions for common cases...
@@ -110,9 +100,9 @@ extension ConstraintGroup {
             file: file,
             line: line,
             composedOf:
-            .setFixed(.width, to: preferred) ~ .defaultHigh,
-            .align(.leading, .greaterThanOrEqual, to: secondItem),
-            .align(.trailing, .lessThanOrEqual, to: secondItem)
+            .fixedWidth(preferred) ~ .defaultHigh,
+            .leading(.greaterThanOrEqual, to: secondItem),
+            .trailing(.lessThanOrEqual, to: secondItem)
         )
     }
 }

--- a/Sources/Constraints/ConstrainableItem.swift
+++ b/Sources/Constraints/ConstrainableItem.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Sources/Constraints/ConstraintGroup+Anchors.swift
+++ b/Sources/Constraints/ConstraintGroup+Anchors.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -45,7 +45,7 @@ extension ConstraintGroup {
         file: StaticString = #file,
         line: UInt = #line
         ) -> ConstraintGroup {
-        return ConstraintGroup(
+        return .init(
             file: file,
             line: line,
             specs: { item in
@@ -67,7 +67,7 @@ extension ConstraintGroup {
                         multiplier: multiplier
                     )
                 }
-            })
+        })
     }
 
     /// Returns a `ConstraintGroup` for aligning an item below another item plus
@@ -89,7 +89,7 @@ extension ConstraintGroup {
         file: StaticString = #file,
         line: UInt = #line
         ) -> ConstraintGroup {
-        return ConstraintGroup(
+        return .init(
             file: file,
             line: line,
             specs: { item in
@@ -111,7 +111,7 @@ extension ConstraintGroup {
                         multiplier: multiplier
                     )
                 }
-            })
+        })
     }
 
     /// Returns a `ConstraintGroup` for matching an item's dimension to the
@@ -137,7 +137,7 @@ extension ConstraintGroup {
         file: StaticString = #file,
         line: UInt = #line
         ) -> ConstraintGroup {
-        return ConstraintGroup(
+        return .init(
             file: file,
             line: line,
             specs: { item in
@@ -165,7 +165,7 @@ extension ConstraintGroup {
                         constant: constant
                     )
                 }
-            })
+        })
     }
 
     /// Returns a `ConstraintGroup` for matching an item's dimension to the
@@ -191,7 +191,7 @@ extension ConstraintGroup {
         file: StaticString = #file,
         line: UInt = #line
         ) -> ConstraintGroup {
-        return ConstraintGroup(
+        return .init(
             file: file,
             line: line,
             specs: { item in
@@ -219,6 +219,6 @@ extension ConstraintGroup {
                         constant: constant
                     )
                 }
-            })
+        })
     }
 }

--- a/Sources/Constraints/ConstraintGroup+Extensions.swift
+++ b/Sources/Constraints/ConstraintGroup+Extensions.swift
@@ -30,7 +30,7 @@ extension ConstraintGroup {
     ///
     /// - Parameters:
     ///   - secondItem: The item you are making the constraint against; defaults to
-    ///     the `superview` if left as `nil`.
+    ///   the `superview` if left as `nil`.
     ///   - insets: The desired insets; defaults to `.zero`.
     /// - Returns: A `ConstraintGroup` for aligning an item's edges to another
     ///   item.
@@ -45,10 +45,10 @@ extension ConstraintGroup {
             file: file,
             line: line,
             composedOf:
-            .align(.top, to: secondItem, constant: insets.top, file: file, line: line),
-            .align(.leading, to: secondItem, constant: insets.leading, file: file, line: line),
-            .align(.bottom, to: secondItem, constant: -insets.bottom, file: file, line: line),
-            .align(.trailing, to: secondItem, constant: -insets.trailing, file: file, line: line)
+            .top(to: secondItem, constant: insets.top, file: file, line: line),
+            .leading(to: secondItem, constant: insets.leading, file: file, line: line),
+            .bottom(to: secondItem, constant: -insets.bottom, file: file, line: line),
+            .trailing(to: secondItem, constant: -insets.trailing, file: file, line: line)
         )
     }
 
@@ -57,7 +57,7 @@ extension ConstraintGroup {
     ///
     /// - Parameters:
     ///   - secondItem: The item you are making the constraint against; defaults to
-    ///     the `superview` if left as `nil`.
+    ///   the `superview` if left as `nil`.
     ///   - leadingInset: The desired leading inset; defaults to zero.
     ///   - trailingInset: The desired trailing inset; defaults to zero.
     /// - Returns: A `ConstraintGroup` for aligning an item's vertical edges to
@@ -74,8 +74,8 @@ extension ConstraintGroup {
             file: file,
             line: line,
             composedOf:
-            .align(.leading, to: secondItem, constant: leadingInset, file: file, line: line),
-            .align(.trailing, to: secondItem, constant: -trailingInset, file: file, line: line)
+            .leading(to: secondItem, constant: leadingInset, file: file, line: line),
+            .trailing(to: secondItem, constant: -trailingInset, file: file, line: line)
         )
     }
 
@@ -101,16 +101,16 @@ extension ConstraintGroup {
             file: file,
             line: line,
             composedOf:
-            .align(.top, to: secondItem, constant: topInset, file: file, line: line),
-            .align(.bottom, to: secondItem, constant: -bottomInset, file: file, line: line)
+            .top(to: secondItem, constant: topInset, file: file, line: line),
+            .bottom(to: secondItem, constant: -bottomInset, file: file, line: line)
         )
     }
 
     /// Returns a `ConstraintGroup` for centering an item inside another item.
     ///
     /// - Parameters:
-    ///   - secondItem: The item you are making the constraint against; defaults to
-    ///     the `superview` if left as `nil`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///   to the `superview` if left as `nil`.
     /// - Returns: A `ConstraintGroup` for centering an item inside another
     ///   item.
     @inlinable
@@ -123,41 +123,8 @@ extension ConstraintGroup {
             file: file,
             line: line,
             composedOf:
-            .align(.centerX, to: secondItem, file: file, line: line),
-            .align(.centerY, to: secondItem, file: file, line: line)
-        )
-    }
-
-    /// Returns a `ConstraintGroup` for aligning multiple attributes.
-    ///
-    /// - Parameters:
-    ///   - attributes: The list of attributes to match.
-    ///   - secondItem: The item you are making the constraint against; defaults to
-    ///     the `superview` if left as `nil`.
-    /// - Returns: A `ConstraintGroup` that aligns multiple attributes.
-    @inlinable
-    public static func align(
-        _ attributes: [NSLayoutConstraint.Attribute],
-        to secondItem: ConstrainableItem? = nil,
-        file: StaticString = #file,
-        line: UInt = #line
-        ) -> ConstraintGroup {
-        return .init(
-            file: file,
-            line: line,
-            specs:
-            attributes.map { attribute in
-                constraintGenerator(
-                    firstAttribute: attribute,
-                    relation: .equal,
-                    secondItem: secondItem,
-                    secondAttribute: attribute,
-                    multiplier: 1,
-                    constant: 0,
-                    file: file,
-                    line: line
-                )
-            }
+            .centerX(to: secondItem, file: file, line: line),
+            .centerY(to: secondItem, file: file, line: line)
         )
     }
 
@@ -172,7 +139,6 @@ extension ConstraintGroup {
         _ relation: Relation = .equal,
         to size: CGSize,
         file: StaticString = #file,
-        function: StaticString = #function,
         line: UInt = #line
         ) -> ConstraintGroup {
         return .init(
@@ -184,13 +150,49 @@ extension ConstraintGroup {
         )
     }
 
+    /// Returns a `ConstraintGroup` for setting the size of an item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - size: The desired size.
+    /// - Returns: A `ConstraintGroup` for setting the size of an item.
+    @inlinable
+    public static func size(
+        _ relation: Relation,
+        _ size: CGSize,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            composedOf:
+            .fixedWidth(relation, size.width, file: file, line: line),
+            .fixedHeight(relation, size.height, file: file, line: line)
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for setting the size of an item.
+    ///
+    /// - Parameters:
+    ///   - size: The desired size.
+    /// - Returns: A `ConstraintGroup` for setting the size of an item.
+    @inlinable
+    public static func size(
+        _ size: CGSize,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .size(.equal, size, file: file, line: line)
+    }
+
     /// Returns a `ConstraintGroup` for matching the size of one item to another
     /// item.
     ///
     /// - Parameters:
     ///   - relation: The relation; defaults to `.equal`.
-    ///   - secondItem: The item you are making the constraint against; defaults to
-    ///     the `superview` if left as `nil`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///   to the `superview` if left as `nil`.
     ///   - multiplier: The desired multiplier; defaults to `1`.
     ///   - constant: The constant; defaults to `0`.
     /// - Returns: A `ConstraintGroup` for matching the size of one item to
@@ -210,6 +212,35 @@ extension ConstraintGroup {
             composedOf:
             .setRelative(.width, relation, to: secondItem, multiplier: multiplier, constant: constant, file: file, line: line),
             .setRelative(.height, relation, to: secondItem, multiplier: multiplier, constant: constant, file: file, line: line)
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for matching the size of one item to another
+    /// item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///   to the `superview` if left as `nil`.
+    ///   - multiplier: The desired multiplier; defaults to `1`.
+    ///   - constant: The constant; defaults to `0`.
+    /// - Returns: A `ConstraintGroup` for matching the size of one item to
+    ///   another item.
+    @inlinable
+    public static func relativeSize(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            composedOf:
+            .relativeWidth(relation, to: secondItem, multiplier: multiplier, constant: constant, file: file, line: line),
+            .relativeHeight(relation, to: secondItem, multiplier: multiplier, constant: constant, file: file, line: line)
         )
     }
 }

--- a/Sources/Constraints/ConstraintGroup+Operators.swift
+++ b/Sources/Constraints/ConstraintGroup+Operators.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Sources/Constraints/ConstraintGroup.swift
+++ b/Sources/Constraints/ConstraintGroup.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -156,7 +156,7 @@ public struct ConstraintGroup {
                 constant: constant,
                 file: file,
                 line: line
-        )
+            )
         )
     }
 
@@ -202,6 +202,406 @@ public struct ConstraintGroup {
         )
     }
 
+    /// Returns a `ConstraintGroup` for aligning an item's left anchor to
+    /// another item's x anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `XAttribute`; defaults to
+    ///     `left` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's left anchor to
+    ///   another item's x anchor.
+    @inlinable
+    public static func left(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: XAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .left,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's right anchor to
+    /// another item's x anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `XAttribute`; defaults to
+    ///     `right` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's right anchor to
+    ///   another item's x anchor.
+    @inlinable
+    public static func right(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: XAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .right,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's leading anchor to
+    /// another item's x anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `XAttribute`; defaults to
+    ///     `leading` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's leading anchor to
+    ///   another item's x anchor.
+    @inlinable
+    public static func leading(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: XAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .leading,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's trailing anchor to
+    /// another item's x anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `XAttribute`; defaults to
+    ///     `trailing` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's trailing anchor to
+    ///   another item's x anchor.
+    @inlinable
+    public static func trailing(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: XAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .trailing,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's centerX anchor to
+    /// another item's x anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `XAttribute`; defaults to
+    ///     `centerX` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's centerX anchor to
+    ///   another item's x anchor.
+    @inlinable
+    public static func centerX(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: XAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .centerX,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's centerY anchor to
+    /// another item's y anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `YAttribute`; defaults to
+    ///     `centerY` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's centerY anchor to
+    ///   another item's y anchor.
+    @inlinable
+    public static func centerY(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: YAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .centerY,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's top anchor to
+    /// another item's y anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `YAttribute`; defaults to
+    ///     `top` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's top anchor to
+    ///   another item's y anchor.
+    @inlinable
+    public static func top(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: YAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .top,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's bottom anchor to
+    /// another item's y anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `YAttribute`; defaults to
+    ///     `bottom` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's bottom anchor to
+    ///   another item's y anchor.
+    @inlinable
+    public static func bottom(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: YAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .bottom,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's firstBaseline anchor
+    /// to another item's y anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `YAttribute`; defaults to
+    ///     `firstBaseline` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's firstBaseline
+    ///   anchor to another item's y anchor.
+    @inlinable
+    public static func firstBaseline(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: YAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .firstBaseline,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for aligning an item's lastBaseline anchor
+    /// to another item's y anchor.
+    ///
+    /// - Parameters:
+    ///   - relation: A layout relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults
+    ///     to the `superview` if left as `nil`.
+    ///   - secondAttribute: The second `YAttribute`; defaults to
+    ///     `lastBaseline` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant; defaults to 0.
+    /// - Returns: A `ConstraintGroup` for aligning an item's lastBaseline
+    ///   anchor to another item's y anchor.
+    @inlinable
+    public static func lastBaseline(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: YAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .lastBaseline,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
     /// Returns a `ConstraintGroup` for applying a fixed dimension to an item.
     ///
     /// - Parameters:
@@ -211,28 +611,114 @@ public struct ConstraintGroup {
     /// - Returns: A `ConstraintGroup` for applying a fixed dimension to an
     ///   item.
     @inlinable
-    public static func setFixed
-        (
+    public static func setFixed(
         _ firstAttribute: DimensionAttribute,
         _ relation: Relation = .equal,
         to constant: CGFloat,
         file: StaticString = #file,
         line: UInt = #line
-        )
-        -> ConstraintGroup {
-            return .init(
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: firstAttribute.attribute,
+                relation: relation,
+                secondAttribute: .notAnAttribute,
+                constant: constant,
                 file: file,
-                line: line,
-                specs:
-                constraintGenerator(
-                    firstAttribute: firstAttribute.attribute,
-                    relation: relation,
-                    secondAttribute: .notAnAttribute,
-                    constant: constant,
-                    file: file,
-                    line: line
-                )
+                line: line
             )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for applying a fixed width to an item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a fixed width to an
+    ///   item.
+    @inlinable
+    public static func fixedWidth(
+        _ relation: Relation,
+        _ constant: CGFloat,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .width,
+                relation: relation,
+                secondAttribute: .notAnAttribute,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for applying a fixed width to an item.
+    ///
+    /// - Parameters:
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a fixed width to an
+    ///   item.
+    @inlinable
+    public static func fixedWidth(
+        _ constant: CGFloat,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .fixedWidth(.equal, constant, file: file, line: line)
+    }
+
+    /// Returns a `ConstraintGroup` for applying a fixed height to an item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a fixed height to an
+    ///   item.
+    @inlinable
+    public static func fixedHeight(
+        _ relation: Relation,
+        _ constant: CGFloat,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .height,
+                relation: relation,
+                secondAttribute: .notAnAttribute,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for applying a fixed height to an item.
+    ///
+    /// - Parameters:
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a fixed height to an
+    ///   item.
+    @inlinable
+    public static func fixedHeight(
+        _ constant: CGFloat,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .fixedHeight(.equal, constant, file: file, line: line)
     }
 
     /// Returns a `ConstraintGroup` for applying a relative dimension in
@@ -250,8 +736,7 @@ public struct ConstraintGroup {
     /// - Returns: A `ConstraintGroup` for applying a relative dimension in
     ///   relation to another item.
     @inlinable
-    public static func setRelative
-        (
+    public static func setRelative(
         _ firstAttribute: DimensionAttribute,
         _ relation: Relation = .equal,
         to secondItem: ConstrainableItem? = nil,
@@ -260,22 +745,101 @@ public struct ConstraintGroup {
         constant: CGFloat = 0,
         file: StaticString = #file,
         line: UInt = #line
-        )
-        -> ConstraintGroup {
-            return .init(
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: firstAttribute.attribute,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
                 file: file,
-                line: line,
-                specs:
-                constraintGenerator(
-                    firstAttribute: firstAttribute.attribute,
-                    relation: relation,
-                    secondItem: secondItem,
-                    secondAttribute: (secondAttribute ?? firstAttribute).attribute,
-                    multiplier: multiplier,
-                    constant: constant,
-                    file: file,
-                    line: line
-                )
+                line: line
             )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for applying a relative width in relation to
+    /// another item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults to
+    ///     the `superview` if left as `nil`.
+    ///   - secondAttribute: The dimension of the second item; defaults to
+    ///     `width` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a relative width in relation
+    ///   to another item.
+    @inlinable
+    public static func relativeWidth(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: DimensionAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .width,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
+    }
+
+    /// Returns a `ConstraintGroup` for applying a relative height in relation to
+    /// another item.
+    ///
+    /// - Parameters:
+    ///   - relation: The relation; defaults to `.equal`.
+    ///   - secondItem: The item you are making the constraint against; defaults to
+    ///     the `superview` if left as `nil`.
+    ///   - secondAttribute: The dimension of the second item; defaults to
+    ///     `height` if left as `nil`.
+    ///   - multiplier: The multiplier; defaults to 1.
+    ///   - constant: The constant.
+    /// - Returns: A `ConstraintGroup` for applying a relative height in
+    ///   relation to another item.
+    @inlinable
+    public static func relativeHeight(
+        _ relation: Relation = .equal,
+        to secondItem: ConstrainableItem? = nil,
+        attribute secondAttribute: DimensionAttribute? = nil,
+        multiplier: CGFloat = 1,
+        constant: CGFloat = 0,
+        file: StaticString = #file,
+        line: UInt = #line
+        ) -> ConstraintGroup {
+        return .init(
+            file: file,
+            line: line,
+            specs:
+            constraintGenerator(
+                firstAttribute: .height,
+                relation: relation,
+                secondItem: secondItem,
+                secondAttribute: secondAttribute?.attribute,
+                multiplier: multiplier,
+                constant: constant,
+                file: file,
+                line: line
+            )
+        )
     }
 }

--- a/Sources/Constraints/TypeSafeAttributes.swift
+++ b/Sources/Constraints/TypeSafeAttributes.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Tests/ConstraintGroupTests.swift
+++ b/Tests/ConstraintGroupTests.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -99,6 +99,246 @@ class ConstraintGroupTests: XCTestCase {
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
+    func testLeft() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .left,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .right,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.left(.greaterThanOrEqual, to: view2, attribute: .right, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testLeftDefaults() {
+        let desiredConstraints = [
+            view1.leftAnchor.constraint(equalTo: parentView.leftAnchor)
+        ]
+        let constraints = view1.makeConstraints(.left())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRight() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .right,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .left,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.right(.greaterThanOrEqual, to: view2, attribute: .left, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRightDefaults() {
+        let desiredConstraints = [
+            view1.rightAnchor.constraint(equalTo: parentView.rightAnchor)
+        ]
+        let constraints = view1.makeConstraints(.right())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testLeading() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .leading,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .trailing,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.leading(.greaterThanOrEqual, to: view2, attribute: .trailing, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testLeadingDefaults() {
+        let desiredConstraints = [
+            view1.leadingAnchor.constraint(equalTo: parentView.leadingAnchor)
+        ]
+        let constraints = view1.makeConstraints(.leading())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testTrailing() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .trailing,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .leading,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.trailing(.greaterThanOrEqual, to: view2, attribute: .leading, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testTrailingDefaults() {
+        let desiredConstraints = [
+            view1.trailingAnchor.constraint(equalTo: parentView.trailingAnchor)
+        ]
+        let constraints = view1.makeConstraints(.trailing())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testCenterX() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .centerX,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .leading,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.centerX(.greaterThanOrEqual, to: view2, attribute: .leading, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testCenterXDefaults() {
+        let desiredConstraints = [
+            view1.centerXAnchor.constraint(equalTo: parentView.centerXAnchor)
+        ]
+        let constraints = view1.makeConstraints(.centerX())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testCenterY() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .centerY,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .top,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.centerY(.greaterThanOrEqual, to: view2, attribute: .top, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testCenterYDefaults() {
+        let desiredConstraints = [
+            view1.centerYAnchor.constraint(equalTo: parentView.centerYAnchor)
+        ]
+        let constraints = view1.makeConstraints(.centerY())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testTop() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .top,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .centerY,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.top(.greaterThanOrEqual, to: view2, attribute: .centerY, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testTopDefaults() {
+        let desiredConstraints = [
+            view1.topAnchor.constraint(equalTo: parentView.topAnchor)
+        ]
+        let constraints = view1.makeConstraints(.top())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testBottom() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .bottom,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .centerY,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.bottom(.greaterThanOrEqual, to: view2, attribute: .centerY, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testBottomDefaults() {
+        let desiredConstraints = [
+            view1.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
+        ]
+        let constraints = view1.makeConstraints(.bottom())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testFirstBaseline() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .firstBaseline,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .centerY,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.firstBaseline(.greaterThanOrEqual, to: view2, attribute: .centerY, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testFirstBaselineDefaults() {
+        let desiredConstraints = [
+            view1.firstBaselineAnchor.constraint(equalTo: parentView.firstBaselineAnchor)
+        ]
+        let constraints = view1.makeConstraints(.firstBaseline())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testLastBaseline() {
+        let desiredConstraints = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .lastBaseline,
+                relatedBy: .greaterThanOrEqual,
+                toItem: view2,
+                attribute: .centerY,
+                multiplier: 2,
+                constant: 8
+            )
+        ]
+        let constraints = view1.makeConstraints(.lastBaseline(.greaterThanOrEqual, to: view2, attribute: .centerY, multiplier: 2, constant: 8))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testLastBaselineDefaults() {
+        let desiredConstraints = [
+            view1.lastBaselineAnchor.constraint(equalTo: parentView.lastBaselineAnchor)
+        ]
+        let constraints = view1.makeConstraints(.lastBaseline())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
     func testFixed() {
         let desiredConstraints = [
             view1.widthAnchor.constraint(greaterThanOrEqualToConstant: 100)
@@ -115,6 +355,38 @@ class ConstraintGroupTests: XCTestCase {
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
+    func testFixedWidth() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(greaterThanOrEqualToConstant: 100)
+        ]
+        let constraints = view1.makeConstraints(.fixedWidth(.greaterThanOrEqual, 100))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testFixedWidthDefaults() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(equalToConstant: 100)
+        ]
+        let constraints = view1.makeConstraints(.fixedWidth(100))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testFixedHeight() {
+        let desiredConstraints = [
+            view1.heightAnchor.constraint(greaterThanOrEqualToConstant: 100)
+        ]
+        let constraints = view1.makeConstraints(.fixedHeight(.greaterThanOrEqual, 100))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testFixedHeightDefaults() {
+        let desiredConstraints = [
+            view1.heightAnchor.constraint(equalToConstant: 100)
+        ]
+        let constraints = view1.makeConstraints(.fixedHeight(100))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
     func testRelative() {
         let desiredConstraints = [
             view1.widthAnchor.constraint(greaterThanOrEqualTo: view2.heightAnchor, multiplier: 0.5, constant: 2)
@@ -128,6 +400,38 @@ class ConstraintGroupTests: XCTestCase {
             view1.widthAnchor.constraint(equalTo: parentView.widthAnchor, multiplier: 1, constant: 0)
         ]
         let constraints = view1.makeConstraints(.setRelative(.width))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRelativeWidth() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(lessThanOrEqualTo: view2.heightAnchor, multiplier: 0.5, constant: 2)
+        ]
+        let constraints = view1.makeConstraints(.relativeWidth(.lessThanOrEqual, to: view2, attribute: .height, multiplier: 0.5, constant: 2))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRelativeWidthDefaults() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(equalTo: parentView.widthAnchor, multiplier: 1, constant: 0)
+        ]
+        let constraints = view1.makeConstraints(.relativeWidth())
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRelativeHeight() {
+        let desiredConstraints = [
+            view1.heightAnchor.constraint(greaterThanOrEqualTo: view2.widthAnchor, multiplier: 0.5, constant: 2)
+        ]
+        let constraints = view1.makeConstraints(.relativeHeight(.greaterThanOrEqual, to: view2, attribute: .width, multiplier: 0.5, constant: 2))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRelativeHeightDefaults() {
+        let desiredConstraints = [
+            view1.heightAnchor.constraint(equalTo: parentView.heightAnchor, multiplier: 1, constant: 0)
+        ]
+        let constraints = view1.makeConstraints(.relativeHeight())
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
@@ -189,24 +493,6 @@ class ConstraintGroupTests: XCTestCase {
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
-    func testAlignMultipleDefaults() {
-        let desiredConstraints = [
-            view1.centerXAnchor.constraint(equalTo: parentView.centerXAnchor),
-            view1.centerYAnchor.constraint(equalTo: parentView.centerYAnchor)
-        ]
-        let constraints = view1.makeConstraints(.align([.centerX, .centerY]))
-        XCTAssertEqualConstraints(desiredConstraints, constraints)
-    }
-
-    func testAlignMultiple() {
-        let desiredConstraints = [
-            view1.centerXAnchor.constraint(equalTo: view2.centerXAnchor),
-            view1.centerYAnchor.constraint(equalTo: view2.centerYAnchor)
-        ]
-        let constraints = view1.makeConstraints(.align([.centerX, .centerY], to: view2))
-        XCTAssertEqualConstraints(desiredConstraints, constraints)
-    }
-
     func testCenter() {
         let desiredConstraints = [
             view1.centerXAnchor.constraint(equalTo: view2.centerXAnchor),
@@ -236,12 +522,43 @@ class ConstraintGroupTests: XCTestCase {
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
+    func testSize() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(equalToConstant: 1),
+            view1.heightAnchor.constraint(equalToConstant: 2)
+        ]
+
+        var constraints = [NSLayoutConstraint]()
+        constraints = view1.makeConstraints(.size(CGSize(width: 1, height: 2)))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testSizeRelation() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(greaterThanOrEqualToConstant: 1),
+            view1.heightAnchor.constraint(greaterThanOrEqualToConstant: 2)
+        ]
+
+        var constraints = [NSLayoutConstraint]()
+        constraints = view1.makeConstraints(.size(.greaterThanOrEqual, CGSize(width: 1, height: 2)))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
     func testSetRelativeSize() {
         let desiredConstraints = [
             view1.widthAnchor.constraint(greaterThanOrEqualTo: view2.widthAnchor, multiplier: 0.5, constant: 2),
             view1.heightAnchor.constraint(greaterThanOrEqualTo: view2.heightAnchor, multiplier: 0.5, constant: 2)
         ]
         let constraints = view1.makeConstraints(.setRelativeSize(.greaterThanOrEqual, to: view2, multiplier: 0.5, constant: 2))
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testRelativeSize() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(greaterThanOrEqualTo: view2.widthAnchor, multiplier: 0.5, constant: 2),
+            view1.heightAnchor.constraint(greaterThanOrEqualTo: view2.heightAnchor, multiplier: 0.5, constant: 2)
+        ]
+        let constraints = view1.makeConstraints(.relativeSize(.greaterThanOrEqual, to: view2, multiplier: 0.5, constant: 2))
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
@@ -263,6 +580,18 @@ class ConstraintGroupTests: XCTestCase {
 
         var constraints = [NSLayoutConstraint]()
         constraints = view1.makeConstraints(.setFixed(.width, to: 100) ~ .defaultLow)
+        XCTAssertEqualConstraints(desiredConstraints, constraints)
+    }
+
+    func testPriorityOperatorWithFloat() {
+        let desiredConstraints = [
+            view1.widthAnchor.constraint(equalToConstant: 100)
+        ]
+
+        desiredConstraints.forEach { $0.priority = .init(250) }
+
+        var constraints = [NSLayoutConstraint]()
+        constraints = view1.makeConstraints(.setFixed(.width, to: 100) ~ 250)
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
 
@@ -363,11 +692,11 @@ class ConstraintGroupTests: XCTestCase {
 
     func testMatchDimensionX() {
         let desiredConstraints = [
-            view1.heightAnchor.constraint(greaterThanOrEqualTo: view2.leadingAnchor.anchorWithOffset(to: parentView.leadingAnchor), multiplier: 2, constant: 1),
+            view1.widthAnchor.constraint(greaterThanOrEqualTo: view2.leadingAnchor.anchorWithOffset(to: parentView.leadingAnchor), multiplier: 2, constant: 1),
             view1.widthAnchor.constraint(lessThanOrEqualTo: view2.leadingAnchor.anchorWithOffset(to: parentView.leadingAnchor), multiplier: 2, constant: 1)
         ]
         let constraints = view1.makeConstraints(
-            .match(.height, .greaterThanOrEqual, toSpaceBetween: view2.leadingAnchor, and: parentView.leadingAnchor, multiplier: 2, constant: 1),
+            .match(.width, .greaterThanOrEqual, toSpaceBetween: view2.leadingAnchor, and: parentView.leadingAnchor, multiplier: 2, constant: 1),
             .match(.width, .lessThanOrEqual, toSpaceBetween: view2.leadingAnchor, and: parentView.leadingAnchor, multiplier: 2, constant: 1)
         )
         XCTAssertEqualConstraints(desiredConstraints, constraints)
@@ -375,10 +704,10 @@ class ConstraintGroupTests: XCTestCase {
 
     func testMatchDimensionXDefaults() {
         let desiredConstraints = [
-            view1.heightAnchor.constraint(equalTo: view2.topAnchor.anchorWithOffset(to: parentView.topAnchor))
+            view1.widthAnchor.constraint(equalTo: view2.topAnchor.anchorWithOffset(to: parentView.topAnchor))
         ]
         let constraints = view1.makeConstraints(
-            .match(.height, toSpaceBetween: view2.topAnchor, and: parentView.topAnchor)
+            .match(.width, toSpaceBetween: view2.leadingAnchor, and: parentView.leadingAnchor)
         )
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }
@@ -386,11 +715,11 @@ class ConstraintGroupTests: XCTestCase {
     func testMatchDimensionY() {
         let desiredConstraints = [
             view1.heightAnchor.constraint(greaterThanOrEqualTo: view2.topAnchor.anchorWithOffset(to: parentView.topAnchor), multiplier: 2, constant: 1),
-            view1.widthAnchor.constraint(lessThanOrEqualTo: view2.topAnchor.anchorWithOffset(to: parentView.topAnchor), multiplier: 2, constant: 1)
+            view1.heightAnchor.constraint(lessThanOrEqualTo: view2.topAnchor.anchorWithOffset(to: parentView.topAnchor), multiplier: 2, constant: 1)
         ]
         let constraints = view1.makeConstraints(
             .match(.height, .greaterThanOrEqual, toSpaceBetween: view2.topAnchor, and: parentView.topAnchor, multiplier: 2, constant: 1),
-            .match(.width, .lessThanOrEqual, toSpaceBetween: view2.topAnchor, and: parentView.topAnchor, multiplier: 2, constant: 1)
+            .match(.height, .lessThanOrEqual, toSpaceBetween: view2.topAnchor, and: parentView.topAnchor, multiplier: 2, constant: 1)
         )
         XCTAssertEqualConstraints(desiredConstraints, constraints)
     }

--- a/Tests/DynamicLayoutTests.swift
+++ b/Tests/DynamicLayoutTests.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Tests/TestConstraintAutoIdentifiers.swift
+++ b/Tests/TestConstraintAutoIdentifiers.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/Tests/TypeSafeAttributeAnchorTests.swift
+++ b/Tests/TypeSafeAttributeAnchorTests.swift
@@ -1,18 +1,18 @@
 /*
  The MIT License (MIT)
-
+ 
  Copyright (c) 2019 Cameron Pulsford
-
+ 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
-
+ 
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
-
+ 
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE


### PR DESCRIPTION
This promotes things like `.leading()` out of `.align(.leading)` and into their own operators.